### PR TITLE
Initial API Setup and Testing

### DIFF
--- a/portfoliocmsapi/portfolio/urls.py
+++ b/portfoliocmsapi/portfolio/urls.py
@@ -1,6 +1,10 @@
 from rest_framework import routers
+from portfoliocmsapi.portfolio.views import *
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register(r"tags", TagViewSet, "tag")
+router.register(r"tech_stack", TechStackViewSet, "techstack")
+router.register(r"projects", ProjectViewSet, "project")
 
 
 urlpatterns = [] + router.urls

--- a/portfoliocmsapi/portfolio/views/project_viewset.py
+++ b/portfoliocmsapi/portfolio/views/project_viewset.py
@@ -1,9 +1,11 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from ..models import Project
 from ..serializers.project_serializer import ProjectSerializer
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
+    permission_classes = [AllowAny]
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
 

--- a/portfoliocmsapi/portfolio/views/tag_viewset.py
+++ b/portfoliocmsapi/portfolio/views/tag_viewset.py
@@ -1,8 +1,10 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from ..models import Tag
 from ..serializers.tag_serializer import TagSerializer
 
 
 class TagViewSet(viewsets.ModelViewSet):
+    permission_classes = [AllowAny]
     queryset = Tag.objects.all()
     serializer_class = TagSerializer

--- a/portfoliocmsapi/portfolio/views/tech_stack_viewset.py
+++ b/portfoliocmsapi/portfolio/views/tech_stack_viewset.py
@@ -1,8 +1,10 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from ..models import TechStack
 from ..serializers.tech_stack_serializer import TechStackSerializer
 
 
 class TechStackViewSet(viewsets.ModelViewSet):
+    permission_classes = [AllowAny]
     queryset = TechStack.objects.all()
     serializer_class = TechStackSerializer


### PR DESCRIPTION
### Initial API Setup and Testing

This PR establishes basic routing and temporarily configures permissions for initial testing.

**Changes:**
- Set up URL routing for portfolio app endpoints (`/api/portfolio/tags`, `/tech_stack`, `/projects`)
- Added `AllowAny` permissions to ViewSets for development/testing
- Confirmed basic CRUD operations working for `Tag` and `TechStack` models
- Laid groundwork for proper authentication to be added later

**Note:** Permission settings are temporary and will be updated with proper authentication once the users app is implemented.

**Testing:**
- Verified `GET`, `POST`, `PUT`, `DELETE` operations for `tags` and `tech_stack` endpoints
- Confirmed correct database entries being created